### PR TITLE
Update theme without updating a new date functionality added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .txt 
+project_notes
+project_notes.txt
 .env
 .xlsx
 package-lock.json

--- a/controllers/mainControllers.js
+++ b/controllers/mainControllers.js
@@ -249,17 +249,19 @@ const Editer = asyncHandler(async(req, res)=>{
     const name  = nom.trim()
 
     //Check name & date
-    const existing_name = db_data.some(d=> name.toLowerCase() === d.name.toLowerCase())
-    const existing_date = db_data.some(d=> date == d.date)
+    //const existing_name = db_data.some(d=> name.toLowerCase() === d.name.toLowerCase())
 
-    console.log(existing_name)
-    console.log(existing_date)
+    //Confirm whether date is not updated
+    const One_data = await Orateur.find({name : nom})
+    let existing_date = false
+
+    if(One_data[0].date != date)
+        existing_date = db_data.some(d=> date == d.date)
 
     // if(existing_name){
     //     res.send('-1') //error - existing name
     //     return false
     // }
-       
 
     if(existing_date){
         res.send('-2') //error - existing date [Just for double security]
@@ -277,6 +279,18 @@ const Editer = asyncHandler(async(req, res)=>{
     res.send('1')
 
 })
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 //CREATE EXCEL FILE 
@@ -338,6 +352,10 @@ const DownloadFile = asyncHandler(async(req, res)=>{
         res.download(file)
     }, 1000);
 })
+
+
+
+
 
 
 //EXPORT TO MAIN-ROUTES

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -44,8 +44,8 @@ $(document).ready(function(){
         $('table tbody').append(`
             <tr>
                 <td class="_id">${id}</td>
-                <td class="text-truncate" style="max-width: 100px;">${name}</td>
-                <td class="text-truncate" style="max-width: 155px;">${theme}</td>
+                <td class="text-truncate" style="max-width: 55px;">${name}</td>
+                <td class="text-truncate" style="max-width: 120px;">${theme}</td>
                 <td class="text-truncate" style="max-width: 100px;">${date}</td>
                 <td>
                     <button class="ui primary button edit" data-bs-toggle="modal" data-bs-target="#exampleModal" data-bs-id="${_id}" data-bs-name="${name}" data-bs-theme="${theme}" data-bs-date="${date}" >Editer</button>
@@ -233,14 +233,16 @@ $(document).ready(function(){
         $inputs.each(function() {
             modal_data[this.name] = $(this).val();
         });
+        console.log(modal_data)
 
         //Validate before sending to the server 
-        if(modal_data.nom =="" || modal_data.date=="")
-            return false
+        if(modal_data.date =="")
+            modal_data.date = modal_data.CurrentDate
         
         if(modal_data.nom.length > 20 || modal_data.theme.length > 80 || modal_data.date.length > 15)
             return false
 
+        //console.log(modal_data)
         //Ajax 
         $.ajax({
             url: '/edit',
@@ -271,9 +273,9 @@ $(document).ready(function(){
                 //On success
                 swal({
                     title: "Félicitations!",
-                    text: "Vous etes notre prochain orateur!",
+                    text: "Vos informations sont à jour!",
                     icon: "success",
-                    button: "Gloire à Dieu!"
+                    button: "Merci Seigneur!"
                 }).then(()=> { window.location = "/"});
 
                 //RESET FORM

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -117,6 +117,11 @@
                             <textarea rows="3" maxlength="80" class="modal-theme" name="theme" placeholder="Votre theme (facultatif)"></textarea>
                         </div>
                         <div class="field">
+                            <div class="ui disabled input">
+                            <input type="text" class="modal-current-date" name="CurrentDate" placeholder="Current date" maxlength="20">
+                        </div>
+                        </div>
+                        <div class="field">
                             <div class="ui fluid selection dropdown" id="modal_dropdown">
                                 <input type="hidden" name="date" maxlength="15">
                                 <i class="dropdown icon"></i>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -59,19 +59,21 @@
 			const modalId = exampleModal.querySelector('#modal_id')
 			const modalName = exampleModal.querySelector('.modal-name')
 			const modalTheme = exampleModal.querySelector('.modal-theme')
+			const modalDate = exampleModal.querySelector('.modal-current-date')
 
 			//Load values
 			modalName.value = nom
 			modalTheme.value = theme
 			modalId.value = id
+			modalDate.value = tableDate
 
 		})
 
 
 		
 
-		//FORM VALIDATION
-		$('.ui.form')
+		//AJOUTER FORM VALIDATION
+		$('#ajouter')
 		.form({
 			fields: {
 			nom: {
@@ -103,6 +105,46 @@
 					type   : 'empty',
 					prompt : 'Vous devez choisir une date'
 				},
+				{
+					type   : 'maxLength[15]',
+					prompt : 'Trop long comme date!'
+				}
+				]
+			},
+			}
+		})
+		;
+
+
+		//METTRE A JOUR FORM VALIDATION 
+		$('#editer')
+		.form({
+			fields: {
+			nom: {
+				identifier: 'nom',
+				rules: [
+				{
+					type   : 'empty',
+					prompt : 'Entrez votre nom s\'il vous plait'
+				},
+				{
+					type   : 'maxLength[20]',
+					prompt : 'Trop long comme nom!'
+				}
+				]
+			},
+			theme: {
+				identifier: 'theme',
+				rules: [
+				{
+					type   : 'maxLength[80]',
+					prompt : 'Votre theme est beaucoup trop long!'
+				}
+				]
+			},
+			date: {
+				identifier: 'date',
+				rules: [
 				{
 					type   : 'maxLength[15]',
 					prompt : 'Trop long comme date!'


### PR DESCRIPTION
A user noticed a limitation in the Edit form's modal. 
They were unable to  update the 'theme' textarea without having to change the date input. 
